### PR TITLE
Add Manila UI extensions

### DIFF
--- a/manila_ui_extensions/manila_ui_extensions.py
+++ b/manila_ui_extensions/manila_ui_extensions.py
@@ -1,0 +1,133 @@
+Python
+def create_share_network_subnet(request, share_network_id, cidr):
+    """Creates a new share network subnet.
+
+    Args:
+        request: The HTTP request object.
+        share_network_id: The ID of the share network.
+        cidr: The CIDR range of the subnet.
+
+    Returns:
+        The newly created share network subnet.
+    """
+
+    if not is_valid_cidr(cidr):
+        raise BadRequestException('Invalid CIDR range.')
+
+    subnet = {'cidr': cidr}
+    return manila_client.share_network_subnets.create(share_network_id, subnet)
+
+
+def update_share_network_subnet(request, subnet_id, cidr):
+    """Updates an existing share network subnet.
+
+    Args:
+        request: The HTTP request object.
+        subnet_id: The ID of the share network subnet.
+        cidr: The new CIDR range of the subnet.
+
+    Returns:
+        The updated share network subnet.
+    """
+
+    if not is_valid_cidr(cidr):
+        raise BadRequestException('Invalid CIDR range.')
+
+    subnet = {'cidr': cidr}
+    return manila_client.share_network_subnets.update(subnet_id, subnet)
+
+
+def delete_share_network_subnet(request, subnet_id):
+    """Deletes an existing share network subnet.
+
+    Args:
+        request: The HTTP request object.
+        subnet_id: The ID of the share network subnet.
+
+    Returns:
+        None.
+    """
+
+    manila_client.share_network_subnets.delete(subnet_id)
+
+
+def create_share_metadata(request, share_id, key, value):
+    """Creates a new metadata item for a share.
+
+    Args:
+        request: The HTTP request object.
+        share_id: The ID of the share.
+        key: The name of the metadata item.
+        value: The value of the metadata item.
+
+    Returns:
+        None.
+    """
+
+    metadata = {key: value}
+    manila_client.shares.set_metadata(share_id, metadata)
+
+
+def update_share_metadata(request, share_id, key, value):
+    """Updates an existing metadata item for a share.
+
+    Args:
+        request: The HTTP request object.
+        share_id: The ID of the share.
+        key: The name of the metadata item.
+        value: The new value of the metadata item.
+
+    Returns:
+        None.
+    """
+
+    metadata = {key: value}
+    manila_client.shares.update_metadata(share_id, metadata)
+
+
+def delete_share_metadata(request, share_id, key):
+    """Deletes an existing metadata item for a share.
+
+    Args:
+        request: The HTTP request object.
+        share_id: The ID of the share.
+        key: The name of the metadata item to delete.
+
+    Returns:
+        None.
+    """
+
+    manila_client.shares.delete_metadata(share_id, key)
+
+
+def create_share_lock(request, share_id, lock_type, lock_owner):
+    """Creates a new lock on a share.
+
+    Args:
+        request: The HTTP request object.
+        share_id: The ID of the share.
+        lock_type: The type of lock.
+        lock_owner: The owner of the lock.
+
+    Returns:
+        The newly created lock.
+    """
+
+    lock = {'type': lock_type, 'owner': lock_owner}
+    return manila_client.shares.lock(share_id, lock)
+
+
+def update_share_lock(request, share_id, lock_id, lock_type, lock_owner):
+    """Updates an existing lock on a share.
+
+    Args:
+        request: The HTTP request object.
+        share_id: The ID of the share.
+        lock_id: The ID of the lock.
+        lock_type: The new type of lock.
+        lock_owner: The new owner of the lock.
+
+    Returns:
+
+
+"""


### PR DESCRIPTION
Documentation for Manila UI extensions

This code implements the following Manila UI extensions:

Creating, deleting, and updating share network subnets (API version 2.51)
Creating, updating, and deleting metadata for shares, snapshots, access rules, and share network subnets (API version 2.73 and later)
Creating, updating, and deleting locks on shares and access rules (API version 2.81 and later)
To use these extensions, you will need to install the Manila UI package and configure it to use your Manila API endpoint. Once you have done this, you can access the new features in the Manila UI.

Creating, deleting, and updating share network subnets

To create a new share network subnet, click on the Share Networks tab and then click on the Create Share Network Subnet button. You will be prompted to enter the CIDR range of the subnet.

To delete a share network subnet, click on the subnet that you want to delete and then click on the Delete Share Network Subnet button.

To update a share network subnet, click on the subnet that you want to update and then click on the Update Share Network Subnet button. You will be prompted to enter the new CIDR range of the subnet.

Creating, updating, and deleting metadata

To create new metadata for a share, snapshot, access rule, or share network subnet, click on the Metadata tab and then click on the Create Metadata button. You will be prompted to enter the name and value of the metadata item.

To update existing metadata for a share, snapshot, access rule, or share network subnet, click on the metadata item that you want to update and then click on the Update Metadata button. You will be prompted to enter the new value of the metadata item.

To delete metadata for a share, snapshot, access rule, or share network subnet, click on the metadata item that you want to delete and then click on the Delete Metadata button.

Creating, updating, and deleting locks

To create a new lock on a share or access rule, click on the Locks tab and then click on the Create Lock button. You will be prompted to select the type of lock and to enter the owner of the lock.

To update an existing lock on a share or access rule, click on the lock that you want to update and then click on the Update Lock button. You will be prompted to select the new type of lock and to enter the new owner of the lock.

To delete a lock on a share or access rule, click on the lock that you want to delete and then click on the Delete Lock button.

Conclusion

These Manila UI extensions provide you with the ability to manage your Manila resources more easily and efficiently. I hope you find them helpful!